### PR TITLE
updates for no-suggests checks

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     knitr,
     parsnip,
     rmarkdown,
+    splines2,
     testthat (>= 3.0.0),
     yardstick
 VignetteBuilder: 

--- a/tests/testthat/test_dplyr_new.R
+++ b/tests/testthat/test_dplyr_new.R
@@ -1,6 +1,4 @@
-library(tidyposterior)
 library(dplyr)
-library(testthat)
 
 data("ex_objects", package = "tidyposterior")
 

--- a/tests/testthat/test_perf_mod.R
+++ b/tests/testthat/test_perf_mod.R
@@ -1,6 +1,6 @@
 ## run fits outside of test functions
 ## https://github.com/stan-dev/rstanarm/issues/202
-if (rlang::is_installed("parsnip", "yardstick")) {
+if (rlang::is_installed(c("parsnip", "yardstick"))) {
   library(rsample)
   library(parsnip)
   library(workflowsets)

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -1,4 +1,3 @@
-library(tidyposterior)
 library(rsample)
 library(testthat)
 library(ggplot2)

--- a/vignettes/articles/Getting_Started.Rmd
+++ b/vignettes/articles/Getting_Started.Rmd
@@ -10,7 +10,7 @@ output:
 
 
 ```{r setup, include=FALSE}
-if (rlang::is_installed(c("tidymodels", "parsnip", "yardstick"))) {
+if (rlang::is_installed(c("tidymodels", "parsnip", "yardstick", "splines2"))) {
   run <- TRUE
 } else {
   run <- FALSE

--- a/vignettes/articles/Getting_Started.Rmd
+++ b/vignettes/articles/Getting_Started.Rmd
@@ -10,7 +10,13 @@ output:
 
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE, fig.align = "center")
+if (rlang::is_installed(c("tidymodels", "parsnip", "yardstick"))) {
+  run <- TRUE
+} else {
+  run <- FALSE
+}
+
+knitr::opts_chunk$set(echo = TRUE, fig.align = "center", eval = run)
 library(tidymodels)
 library(tidyposterior)
 data(two_class_dat)
@@ -50,12 +56,12 @@ logistic_spec <- logistic_reg() %>% set_engine("glm")
 
 ## Comparing modeling/prepreocessing methods
 
-One way to incorporate nonlinearity into the class boundary is to use a spline basis expansion for the predictors. A `recipe` step using `step_ns` will will encode the predictors in this way. The degrees of freedom will be hard-coded to produce two additional feature columns per predictor: 
+One way to incorporate nonlinearity into the class boundary is to use a spline basis expansion for the predictors. A `recipe` step using `step_spline_natural` will will encode the predictors in this way. The degrees of freedom will be hard-coded to produce two additional feature columns per predictor: 
 
 ```{r splines}
 spline_rec <- 
   recipe(Class ~ ., data = two_class_dat) %>% 
-  step_ns(A, B, deg_free = 3)
+  step_spline_natural(A, B, deg_free = 3)
 
 spline_wflow <- 
   workflow() %>% 


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.